### PR TITLE
Changing time format in feed

### DIFF
--- a/source/feed.xml.builder
+++ b/source/feed.xml.builder
@@ -13,9 +13,9 @@ xml.rss "xmlns:itunes" => "http://www.itunes.com/dtds/podcast-1.0.dtd", "version
     xml.id "http://teahour.fm"
     xml.link "href" => "http://teahour.fm/"
     xml.link "href" => "http://teahour.fm/feed.xml", "rel" => "self"
-    xml.updated blog.articles.first.date.to_time.iso8601
-    xml.lastBuildDate blog.articles.first.date.to_time.iso8601
-    xml.pubDate blog.articles.first.date.to_time.iso8601
+    xml.updated blog.articles.first.date.to_time.rfc2822
+    xml.lastBuildDate blog.articles.first.date.to_time.rfc2822
+    xml.pubDate blog.articles.first.date.to_time.rfc2822
     xml.description "Teahour.fm 由 Terry Tai，Dingding Ye, Daniel Lv 和 Kevin Wang 主持，会专注程序员感兴趣的话题，包括 Web 设计和开发，移动应用设计和开发，创业以及一切 Geek 的话题。"
     xml.author { xml.name "Teahour.fm" }
     xml.itunes :owner do
@@ -37,7 +37,7 @@ xml.rss "xmlns:itunes" => "http://www.itunes.com/dtds/podcast-1.0.dtd", "version
         xml.link "http://teahour.fm#{article.url}"
         xml.enclosure "url" => article.data["mp3_link"], "type" => "audio/x-m4a"
         xml.guid article.data["mp3_link"]
-        xml.pubDate article.date.to_time.iso8601
+        xml.pubDate article.date.to_time.rfc2822
         xml.itunes :duration, article.data["duration"]
         xml.itunes :keywords, article.tags.join(", ")
       end


### PR DESCRIPTION
According to http://www.apple.com/itunes/podcasts/specs.html#commonmistakes , podcast feeds for itunes should use RFC 2822 as format for 'pubDate'. This should fix there is no push update when new episodes release and the incorrect sorting issue.
